### PR TITLE
Add `timeout` and `interval` functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude       = [
 [dependencies]
 log     = "0.3.0"
 syncbox = "0.2.0"
+clock_ticks = "0.0.5"
 
 [dev-dependencies]
 time = "0.1.22"

--- a/src/future.rs
+++ b/src/future.rs
@@ -255,6 +255,13 @@ impl<T: Send, E: Send> Cancel<Future<T, E>> for Receipt<Future<T, E>> {
     }
 }
 
+impl Future<(), ()> {
+    pub fn timeout(duration_ms: u32) -> Future<(), ()> {
+        use std::thread::sleep_ms;
+        Future::spawn(move || { sleep_ms(duration_ms) })
+    }
+}
+
 /// An object that is used to fulfill or reject an associated Future.
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 #![crate_name = "eventual"]
 
 extern crate syncbox;
+extern crate clock_ticks;
 
 #[macro_use]
 extern crate log;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -615,16 +615,14 @@ impl Stream<(), ()> {
         fn sleep_then_send(max_ms: u32, how_long: u32, stream: Sender<(), ()>) {
             sleep_ms(how_long);
 
-            let before = precise_time_ns() * 1000;
+            let before = precise_time_ns() / 1000;
             stream.send(()).receive(move |res| {
-                match res {
-                    Ok(s) => {
-                        let after = precise_time_ns() * 1000;
-                        let duration = (after - before) as u32;
-                        sleep_then_send(max_ms, max_ms - duration, s);
-                    }
-                    Err(_) => {}
+                if let Ok(s) = res {
+                    let after = precise_time_ns() / 1000;
+                    let duration = (after - before) as u32;
+                    sleep_then_send(max_ms, max_ms - duration, s);
                 }
+
             });
         }
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -26,6 +26,7 @@ extern crate log;
  */
 
 // == Future tests ==
+mod test_timeout;
 mod test_future_and;
 mod test_future_await;
 mod test_future_cancel;

--- a/test/test_timeout.rs
+++ b/test/test_timeout.rs
@@ -1,0 +1,23 @@
+use eventual::*;
+
+#[test]
+fn test_timeout() {
+    // timeout for 400ms
+    let timeout = Future::timeout(400);
+    assert!(!timeout.is_ready());
+
+    let wait = timeout.await();
+    assert!(wait.is_ok());
+}
+
+#[test]
+fn test_interval() {
+    // triggers every 100ms
+    let interval = Stream::interval(100);
+    let collected = interval.take(4).collect().await();
+
+    assert!(collected.is_ok());
+    let collected = collected.unwrap();
+    println!("{}", collected.len());
+    assert!(collected.len() == 4);
+}

--- a/test/test_timeout.rs
+++ b/test/test_timeout.rs
@@ -18,6 +18,5 @@ fn test_interval() {
 
     assert!(collected.is_ok());
     let collected = collected.unwrap();
-    println!("{}", collected.len());
     assert!(collected.len() == 4);
 }


### PR DESCRIPTION
I tried adding functions that I need for my async code to be pretty.

`Future::timeout` creates a `Future<(), ()>` that will be completed after a certain amount of time has passed.

`Stream::interval` creates `Stream<(), ()>` that is completed repeatedly every `n` milliseconds.  

I think that both function implementations are correct, but I'm at a loss for how to go about writing more tests.  
