### PR TITLE
Make sure defer/background api does not capture thread pool

### DIFF
--- a/test/test_run.rs
+++ b/test/test_run.rs
@@ -11,9 +11,9 @@ use syncbox::ThreadPool;
 #[test]
 fn test_defer_runs_on_thread_pool() {
     // Set thread local
-    let pool = ThreadPool::single_thread();
+    let pool = Arc::new(ThreadPool::single_thread());
     let (complete, future) = Future::<i32, ()>::pair();
-    let res = defer(pool, future).and_then(|v: i32| {
+    let res = defer(pool.clone(), future).and_then(|v: i32| {
         // Assert thread local is not present here
         Ok(v + 5)
     });
@@ -24,17 +24,23 @@ fn test_defer_runs_on_thread_pool() {
 #[test]
 fn test_threadpool_background() {
     // Set thread local
-    let pool = ThreadPool::single_thread();
+    let pool = Arc::new(ThreadPool::single_thread());
     let flag = Arc::new(AtomicBool::new(false));
-    let f = flag.clone();
-    let result = background(pool, Box::new(move || {
-        assert!(f.load(Ordering::Relaxed));
-        5
-    }));
+
+    for x in 0..2 {
+        let f = flag.clone();
+
+        let result = background(pool.clone(), Box::new(move || {
+            assert!(f.load(Ordering::Relaxed));
+            5
+        }));
+        thread::sleep_ms(100);
+        // Set the flag
+        flag.store(true, Ordering::Relaxed);
+        assert_eq!(Ok(5), result.await());
+    }
+
     // Wait for a bit to make sure that the background task hasn't run
 
-    thread::sleep_ms(100);
-    // Set the flag
-    flag.store(true, Ordering::Relaxed);
-    assert_eq!(Ok(5), result.await());
+
 }


### PR DESCRIPTION
Capturing the threadpool is just too much. Perhaps we should be using a borrow instead, but I figure just arcing and cloning will be the easiest for the user.
