### PR TITLE
Fix join to succeed on an empty vector of futures

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -190,6 +190,13 @@ impl<A: Async> Join<Vec<A::Value>, A::Error> for Vec<A> {
             complete,
             self.len() as isize);
 
+        // If we never enter the loop below, it's important that we complete the
+        // future or it will be dropped and then failed
+        if self.len() == 0 {
+            progress.succeed();
+            return;
+        }
+
         for (i, async) in self.into_iter().enumerate() {
             let progress = progress.clone();
 

--- a/test/test_join.rs
+++ b/test/test_join.rs
@@ -117,3 +117,9 @@ pub fn test_joining_two_vec_futures_async() {
 
     assert_eq!(rx.recv().unwrap(), [1, 2]);
 }
+
+#[test]
+pub fn test_empty_join() {
+    let v: Vec<Future<i32, ()>> = vec![];
+    assert_eq!(join(v).await().ok(), Some(vec![]));
+}


### PR DESCRIPTION
If we never enter the loop to process the vector of futures we're joining, then `progress` will be dropped, causing the `Complete` inside to be dropped and cancelled. However, the user probably wants it to successfully yield an empty vector.
