### PR TITLE
Async::when and Complete::complete_async

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -294,6 +294,18 @@ impl<T: Send + 'static, E: Send + 'static> Complete<T, E> {
         core::take(&mut self.core).complete(Err(AsyncError::failed(err)), true);
     }
 
+    /// Complete the associated Future with the ready result of the 
+    /// provided Async.
+    pub fn complete_async<A>(self, async: A) -> Future<(), ()>
+        where A: Async<Value=T, Error=E> {
+        async.when(move |res| {
+            match res {
+                Ok(v) => self.complete(v),
+                Err(e) => self.fail(e)
+            }
+        })
+    }
+
     pub fn abort(self) {
         drop(self);
     }

--- a/test/test_future_receive.rs
+++ b/test/test_future_receive.rs
@@ -282,3 +282,18 @@ pub fn test_ready_fn_does_nothing() {
     complete.complete(123);
     assert_eq!("done", rx.recv().unwrap());
 }
+
+#[test]
+pub fn test_complete_async() {
+    let (complete, future) = Future::<i32, &'static str>::pair();
+    let (tx, rx) = channel();
+
+    future.receive(move |res| {
+        tx.send(res.unwrap()).unwrap();
+    });
+
+    let lazy = Future::<i32, &'static str>::lazy(|| Ok(10));
+
+    complete.complete_async(lazy).await().unwrap();
+    assert_eq!(10, rx.recv().unwrap());
+}


### PR DESCRIPTION
`Async.when` can be thought of as something like `Future.map_result()`.
This is useful for when you need to compute a Future based of the ready
result of a previous Future, and need to move a specific value into it.
The documentation includes an example that cannot be solved with
`and_then` and `or_else` together.

Since this is actually duplicate functionality from `and_then` and
`or_else`, it was consolidated into `when`, and the former methods now
use `when` internally.
