### PR TITLE
Fix compilation error on latest nightly

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -112,13 +112,11 @@ impl<P: Partial<R>, R: Send + 'static, E: Send + 'static> Progress<P, R, E> {
     }
 
     fn inner(&self) -> &ProgressInner<P, R, E> {
-        use std::mem;
-        unsafe { mem::transmute(self.inner.get()) }
+        unsafe { &*self.inner.get() }
     }
 
     fn inner_mut(&self) -> &mut ProgressInner<P, R, E> {
-        use std::mem;
-        unsafe { mem::transmute(self.inner.get()) }
+        unsafe { &mut *self.inner.get() }
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -273,13 +273,13 @@ impl<T: Send + 'static, U: Async, F> ops::Deref for Inner<T, U, F> {
     type Target = Core<T, U, F>;
 
     fn deref(&self) -> &Core<T, U, F> {
-        unsafe { mem::transmute(self.0.get()) }
+        unsafe { &*self.0.get() }
     }
 }
 
 impl<T: Send + 'static, U: Async, F> ops::DerefMut for Inner<T, U, F> {
     fn deref_mut(&mut self) -> &mut Core<T, U, F> {
-        unsafe { mem::transmute(self.0.get()) }
+        unsafe { &mut *self.0.get() }
     }
 }
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -193,13 +193,11 @@ impl<V: Values<S, E>, S: Select<E>, E: Send + 'static> Selection<V, S, E> {
     }
 
     fn core(&self) -> &Core<V, S, E> {
-        use std::mem;
-        unsafe { mem::transmute(self.core.get()) }
+        unsafe { &*self.core.get() }
     }
 
     fn core_mut(&self) -> &mut Core<V, S, E> {
-        use std::mem;
-        unsafe { mem::transmute(self.core.get()) }
+        unsafe { &mut *self.core.get() }
     }
 }
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,5 +1,5 @@
 use {Async, AsyncError, Stream, Sender};
-use std::{mem, ops};
+use std::ops;
 use std::cell::UnsafeCell;
 use std::iter::IntoIterator;
 use std::sync::Arc;
@@ -201,13 +201,13 @@ impl<A: Async> ops::Deref for Inner<A> {
     type Target = Core<A>;
 
     fn deref(&self) -> &Core<A> {
-        unsafe { mem::transmute(self.0.get()) }
+        unsafe { &*self.0.get() }
     }
 }
 
 impl<A: Async> ops::DerefMut for Inner<A> {
     fn deref_mut(&mut self) -> &mut Core<A> {
-        unsafe { mem::transmute(self.0.get()) }
+        unsafe { &mut *self.0.get() }
     }
 }
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -104,5 +104,6 @@ fn spawn<F: FnOnce() + Send + 'static>(f: F) {
 
 fn sleep_ms(ms: usize) {
     use std::thread;
-    thread::sleep_ms(ms as u32);
+    use std::time::Duration;
+    thread::sleep(Duration::from_millis(ms as u64));
 }

--- a/test/test_run.rs
+++ b/test/test_run.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 use eventual::{background, defer, Future, Async};
 
 // TODO figure out how to get rid of unused import error here
@@ -33,7 +34,7 @@ fn test_threadpool_background() {
     }));
     // Wait for a bit to make sure that the background task hasn't run
 
-    thread::sleep_ms(100);
+    thread::sleep(Duration::from_millis(100));
     // Set the flag
     flag.store(true, Ordering::Relaxed);
     assert_eq!(Ok(5), result.await());

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -27,7 +27,7 @@ pub fn test_timer_register_late() {
 
     let timeout = timer.timeout_ms(300);
 
-    thread::sleep_ms(600);
+    thread::sleep(::std::time::Duration::from_millis(600));
 
     let start = SteadyTime::now();
 


### PR DESCRIPTION
These errors were exposing a compiler crash on the latest nightly. See
rust-lang/rust#32377.
