### PR TITLE
Reexport type aliases

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,4 @@
-use {Async, BoxedReceive, AsyncResult, AsyncError};
+use {BoxedReceive, AsyncResult, AsyncError};
 use syncbox::atomic::{self, AtomicU64, AtomicUsize, Ordering};
 use std::{fmt, mem};
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use self::receipt::Receipt;
 pub use self::run::{background, defer};
 pub use self::select::{select, Select};
 pub use self::sequence::sequence;
-pub use self::stream::{Stream, StreamIter, Sender, BusySender};
+pub use self::stream::{Head, Stream, StreamIter, Sender, BusySender};
 pub use self::timer::Timer;
 
 use std::error::Error;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,5 +1,4 @@
-use super::{Async, Pair, AsyncError, Future};
-use syncbox::Task;
+use super::{Async, AsyncError, Future};
 use syncbox::TaskBox;
 use syncbox::Run;
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -104,5 +104,6 @@ fn spawn<F: FnOnce() + Send + 'static>(f: F) {
 
 fn sleep_ms(ms: usize) {
     use std::thread;
-    thread::sleep_ms(ms as u32);
+    use std::time::Duration;
+    thread::sleep(Duration::from_millis(ms as u64));
 }

--- a/test/test.rs
+++ b/test/test.rs
@@ -104,6 +104,5 @@ fn spawn<F: FnOnce() + Send + 'static>(f: F) {
 
 fn sleep_ms(ms: usize) {
     use std::thread;
-    use std::time::Duration;
-    thread::sleep(Duration::from_millis(ms as u64));
+    thread::sleep_ms(ms as u32);
 }

--- a/test/test_run.rs
+++ b/test/test_run.rs
@@ -1,9 +1,9 @@
 extern crate syncbox;
 
+use super::sleep_ms;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::thread;
 use eventual::{background, defer, Future, Async};
 
 // TODO figure out how to get rid of unused import error here
@@ -33,7 +33,7 @@ fn test_threadpool_background() {
     }));
     // Wait for a bit to make sure that the background task hasn't run
 
-    thread::sleep_ms(100);
+    sleep_ms(100);
     // Set the flag
     flag.store(true, Ordering::Relaxed);
     assert_eq!(Ok(5), result.await());

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -1,6 +1,6 @@
+use super::sleep_ms;
 use eventual::{Async, Timer};
 use std::sync::mpsc::*;
-use std::thread;
 use time::{SteadyTime, Duration};
 
 #[test]
@@ -27,7 +27,7 @@ pub fn test_timer_register_late() {
 
     let timeout = timer.timeout_ms(300);
 
-    thread::sleep_ms(600);
+    sleep_ms(600);
 
     let start = SteadyTime::now();
 


### PR DESCRIPTION
I noticed that the `Head` type alias was in the docs, but I had to dig into the code to see what it was. This reexports it so others don't have to do the same! I also fixed up some warnings about the deprecation of `thread::sleep_ms` - I couldn't get rid of all of them though due to travis building against Rust 1.3.
