### PR TITLE
Replace time with std::time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 rust:
   - nightly
   - stable
-  - 1.3.0 # Oldest supported version of Rust
+  - 1.8.0 # Oldest supported version of Rust
 
 script:
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude       = [
 
 [dependencies]
 log     = "0.3.0"
-time    = "0.1.25"
 syncbox = "0.2.3"
 
 [dev-dependencies]

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,4 @@
-use {Async, BoxedReceive, AsyncResult, AsyncError};
+use {BoxedReceive, AsyncResult, AsyncError};
 use syncbox::atomic::{self, AtomicU64, AtomicUsize, Ordering};
 use std::{fmt, mem};
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@
 #![deny(warnings)]
 
 extern crate syncbox;
-extern crate time;
 
 #[macro_use]
 extern crate log;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,7 +1,5 @@
-use super::{Async, Pair, AsyncError, Future};
-use syncbox::Task;
-use syncbox::TaskBox;
-use syncbox::Run;
+use super::{Async, AsyncError, Future};
+use syncbox::{TaskBox, Run};
 
 /// This method defers a task onto a task runner until we can complete that call.
 /// Currently we only support using a ThreadPool as the task runner itself.

--- a/test/test.rs
+++ b/test/test.rs
@@ -16,7 +16,6 @@
 //! # Stream
 
 extern crate eventual;
-extern crate time;
 extern crate syncbox;
 
 #[macro_use]
@@ -85,7 +84,7 @@ fn nums<E: Send>(from: usize, to: usize) -> Stream<usize, E> {
 }
 
 fn futures<T: Send, E: Send>(n: u32) -> (Vec<Complete<T, E>>, Receiver<Future<T, E>>) {
-    let mut v = vec![];
+    let mut v = Vec::with_capacity(n as usize);
     let (tx, rx) = channel();
 
     for _ in 0..n {
@@ -102,7 +101,8 @@ fn spawn<F: FnOnce() + Send + 'static>(f: F) {
     thread::spawn(f);
 }
 
-fn sleep_ms(ms: usize) {
+fn sleep_ms(ms: u64) {
     use std::thread;
-    thread::sleep_ms(ms as u32);
+    use std::time::Duration;
+    thread::sleep(Duration::from_millis(ms));
 }

--- a/test/test_run.rs
+++ b/test/test_run.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 use eventual::{background, defer, Future, Async};
 
 // TODO figure out how to get rid of unused import error here
@@ -33,7 +34,7 @@ fn test_threadpool_background() {
     }));
     // Wait for a bit to make sure that the background task hasn't run
 
-    thread::sleep_ms(100);
+    thread::sleep(Duration::from_millis(100));
     // Set the flag
     flag.store(true, Ordering::Relaxed);
     assert_eq!(Ok(5), result.await());


### PR DESCRIPTION
About to create another for syncbox. Exposing methods which take durations instead of ms in syncbox would help simplify this code
