### PR TITLE
Use `Void` type from `void` crate to mark error types that never occur

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude       = [
 log     = "0.3.0"
 time    = "0.1.25"
 syncbox = "0.2.3"
+void    = "1.0.2"
 
 [dev-dependencies]
 env_logger = "0.3.0"

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,6 +3,7 @@ use syncbox::atomic::{self, AtomicU64, AtomicUsize, Ordering};
 use std::{fmt, mem};
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use std::thread;
+use void::Void;
 
 use self::Lifecycle::*;
 
@@ -78,7 +79,7 @@ impl<T: Send + 'static, E: Send + 'static> Core<T, E> {
         self.inner().producer_is_err()
     }
 
-    pub fn producer_poll(&self) -> Option<AsyncResult<Core<T, E>, ()>> {
+    pub fn producer_poll(&self) -> Option<AsyncResult<Core<T, E>, Void>> {
         self.inner().producer_poll()
     }
 
@@ -424,7 +425,7 @@ impl<T: Send + 'static, E: Send + 'static> CoreInner<T, E> {
         curr.is_canceled()
     }
 
-    pub fn producer_poll(&self) -> Option<AsyncResult<Core<T, E>, ()>> {
+    pub fn producer_poll(&self) -> Option<AsyncResult<Core<T, E>, Void>> {
         let curr = self.state.load(Relaxed);
 
         debug!("Core::producer_poll; state={:?}", curr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ pub trait Cancel<A: Send + 'static> : Send + 'static {
 impl<T: Send + 'static, E: Send + 'static> Async for Result<T, E> {
     type Value = T;
     type Error = E;
-    type Cancel = Option<Void>;
+    type Cancel = Option<Result<T, E>>;
 
     fn is_ready(&self) -> bool {
         true
@@ -307,7 +307,7 @@ impl<T: Send + 'static, E: Send + 'static> Async for Result<T, E> {
         Ok(self.await())
     }
 
-    fn ready<F: FnOnce(Result<T, E>) + Send + 'static>(self, f: F) -> Option<Void> {
+    fn ready<F: FnOnce(Result<T, E>) + Send + 'static>(self, f: F) -> Option<Result<T, E>> {
         f(self);
         None
     }
@@ -316,19 +316,10 @@ impl<T: Send + 'static, E: Send + 'static> Async for Result<T, E> {
         self.map_err(|e| AsyncError::Failed(e))
     }
 }
-/*
+
 impl<A: Send + 'static> Cancel<A> for Option<A> {
     fn cancel(self) -> Option<A> {
         self
-    }
-}*/
-
-impl<A: Send + 'static> Cancel<A> for Option<Void> {
-    fn cancel(self) -> Option<A> {
-        match self {
-            Some(v) => void::unreachable(v),
-            None => None 
-        }
     }
 }
 
@@ -336,7 +327,7 @@ impl<A: Send + 'static> Cancel<A> for Option<Void> {
 impl Async for () {
     type Value  = ();
     type Error  = Void;
-    type Cancel = Option<Void>;
+    type Cancel = Option<()>;
 
     fn is_ready(&self) -> bool {
         true
@@ -350,7 +341,7 @@ impl Async for () {
         Ok(Ok(self))
     }
 
-    fn ready<F: FnOnce(()) + Send + 'static>(self, f: F) -> Option<Void> {
+    fn ready<F: FnOnce(()) + Send + 'static>(self, f: F) -> Option<()> {
         f(self);
         None
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,6 +11,7 @@ use {
 };
 use super::core::{self, Core};
 use std::fmt;
+use void::Void;
 
 /*
  *
@@ -496,7 +497,7 @@ impl<T: Send + 'static, E: Send + 'static> Sender<T, E> {
 
 impl<T: Send + 'static, E: Send + 'static> Async for Sender<T, E> {
     type Value = Sender<T, E>;
-    type Error = ();
+    type Error = Void;
     type Cancel = Receipt<Sender<T, E>>;
 
     fn is_ready(&self) -> bool {
@@ -507,7 +508,7 @@ impl<T: Send + 'static, E: Send + 'static> Async for Sender<T, E> {
         core::get(&self.core).producer_is_err()
     }
 
-    fn poll(mut self) -> Result<AsyncResult<Sender<T, E>, ()>, Sender<T, E>> {
+    fn poll(mut self) -> Result<AsyncResult<Sender<T, E>, Void>, Sender<T, E>> {
         debug!("Sender::poll; is_ready={}", self.is_ready());
 
         let core = core::take(&mut self.core);
@@ -562,7 +563,7 @@ impl<T: Send + 'static, E: Send + 'static> BusySender<T, E> {
 
 impl<T: Send + 'static, E: Send + 'static> Async for BusySender<T, E> {
     type Value = Sender<T, E>;
-    type Error = ();
+    type Error = Void;
     type Cancel = Receipt<BusySender<T, E>>;
 
     fn is_ready(&self) -> bool {
@@ -573,7 +574,7 @@ impl<T: Send + 'static, E: Send + 'static> Async for BusySender<T, E> {
         core::get(&self.core).consumer_is_err()
     }
 
-    fn poll(mut self) -> Result<AsyncResult<Sender<T, E>, ()>, BusySender<T, E>> {
+    fn poll(mut self) -> Result<AsyncResult<Sender<T, E>, Void>, BusySender<T, E>> {
         debug!("Sender::poll; is_ready={}", self.is_ready());
 
         let core = core::take(&mut self.core);
@@ -750,3 +751,4 @@ impl<T: Send + 'static, E: Send + 'static> Drop for StreamIter<T, E> {
 pub fn from_core<T: Send + 'static, E: Send + 'static>(core: StreamCore<T, E>) -> Stream<T, E> {
     Stream { core: Some(core) }
 }
+

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,7 @@
 use {Async, Future, Stream, Sender};
 use syncbox::ScheduledThreadPool;
 use time::{SteadyTime, Duration};
+use void::Void;
 
 /// Provides timeouts as a `Future` and periodic ticks as a `Stream`.
 pub struct Timer {
@@ -21,7 +22,7 @@ impl Timer {
     }
 
     /// Returns a `Future` that will be completed in `ms` milliseconds
-    pub fn timeout_ms(&self, ms: u32) -> Future<(), ()> {
+    pub fn timeout_ms(&self, ms: u32) -> Future<(), Void> {
         let (tx, rx) = Future::pair();
         let pool = self.pool.clone();
         let now = SteadyTime::now();
@@ -45,7 +46,7 @@ impl Timer {
     }
 
     /// Return a `Stream` with values realized every `ms` milliseconds.
-    pub fn interval_ms(&self, ms: u32) -> Stream<(), ()> {
+    pub fn interval_ms(&self, ms: u32) -> Stream<(), Void> {
         let (tx, rx) = Stream::pair();
         let pool = self.pool.clone();
         let interval = Duration::milliseconds(ms as i64);
@@ -62,7 +63,7 @@ fn do_interval<S>(pool: ScheduledThreadPool,
                   sender: S,
                   next: SteadyTime,
                   interval: Duration)
-        where S: Async<Value=Sender<(), ()>> {
+        where S: Async<Value=Sender<(), Void>> {
 
     sender.receive(move |res| {
         if let Ok(sender) = res {


### PR DESCRIPTION
When writing callbacks for `Sender`, `BusySender` and others non-failing `Async` one can wonder:

```
sender.send(|res| {
    match res {
        Ok(sender) => { /*Continue sending values*/ }
        Err(Aborted) => { /*Receiver not interested anymore*/ }
        Err(Failed(_)) => { /*What to do here?*/ }
}
```

However this branch can never occurs. Here is an example how to statically mark this branch so it can never occur as long as typechecker is happy.
